### PR TITLE
Enhance Template Usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "react-superstore",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-superstore",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^17.0.39",
         "typescript": "^4.5.5"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "react": "^18.2.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -23,9 +23,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.39",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "version": "17.0.65",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.65.tgz",
+      "integrity": "sha512-oxur785xZYHvnI7TRS61dXbkIhDPnGfsXKv0cNXR/0ml4SipRIFpSMzA7HMEfOywFwJ5AOnPrXYTEiTRUQeGlQ==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -65,7 +65,7 @@
     },
     "node_modules/react": {
       "version": "18.2.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react/-/react-18.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "peer": true,
       "dependencies": {
@@ -97,9 +97,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.39",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "version": "17.0.65",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.65.tgz",
+      "integrity": "sha512-oxur785xZYHvnI7TRS61dXbkIhDPnGfsXKv0cNXR/0ml4SipRIFpSMzA7HMEfOywFwJ5AOnPrXYTEiTRUQeGlQ==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -136,7 +136,7 @@
     },
     "react": {
       "version": "18.2.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react/-/react-18.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "peer": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-superstore",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Simple hook to create global state in react",
   "keywords": [
     "react",
@@ -25,7 +25,7 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": "^18.2.0"
   },
   "repository": "https://github.com/stevekanger/react-superstore.git",
   "homepage": "https://github.com/stevekanger/react-superstore.git#readme",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,16 +2,16 @@ import { useState, useEffect } from 'react'
 import shouldUpdate from './utils/shouldUpdate'
 import isFn from './utils/isFn'
 
-type Reducer<TStore> = <TAction>(store: TStore, action: TAction) => TStore
+type Reducer<TStore, TAction> = (store: TStore, action: TAction) => TStore
 
 type Listener<TStore> = {
   mapState: (store: TStore) => TStore
   updater: React.Dispatch<React.SetStateAction<TStore>>
 }
 
-const createStore = <TStore>(
+const createStore = <TStore, R extends Reducer<TStore, any>>(
   initialStore: TStore,
-  reducer?: Reducer<TStore>
+  reducer?: R
 ) => {
   let store: TStore = initialStore
   const listeners = new Set<Listener<TStore>>()

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const createStore = <TStore, R extends Reducer<TStore, any>>(
 
   const getStore = () => store
 
-  const dispatch = (action: TStore | ((prev: TStore) => TStore)) => {
+  const dispatch = (action: TStore | ((prev: TStore) => TStore) | ((prev: TStore, action: any) => TStore)) => {
     const oldStore = store
 
     if (reducer) {


### PR DESCRIPTION
Hi,

I've briefly tested the changes, feel free to incorporate them. Some issues I encountered using your fork were:

- Couldn't use a custom reducer method
  - Had to update reducer template definition
- Dispatch to custom reducer actions wasn't possible
  - Updated template logic (borrowed from React) 
- useStore forced to return whole type
  - Created an alternate method 'pickStore'. Uses Pick template. There are two ways one could use this in code:

```
const { user } = pickStore((store: StoreItems) => { return { 
    user: store.user,
    something: store.something
}});
```
Or:
```
const { user, something } = pickStore<'user'|'something'>();
```

I don't like using strings... but, it is using keyof, so, the strings have to be actual property methods... so, refactoring store item names would cause an error in either case.